### PR TITLE
Fix bag with delay

### DIFF
--- a/lcd.c
+++ b/lcd.c
@@ -37,7 +37,7 @@ void lcd_write_nibble(uint8_t nibble) {
   LCD_PORT = LCD_PORT & ~(1 << LCD_EN);
   LCD_PORT = LCD_PORT | (1 << LCD_EN);
   LCD_PORT = LCD_PORT & ~(1 << LCD_EN);
-  _delay_ms(0.04);
+  _delay_ms(0.3);																// If delay less than this value, the data is not correctly displayed  
 }
 
 void lcd_init(void) {


### PR DESCRIPTION
In my project (ATMega128A, internal osc. 8MHz) it's work only if I change delay in function lcd_write_nibble(). If value of this delay less than 0.3ms, display is don't ready to new command. And displayed not all symbols or noise.