### PR TITLE
improving the obviousness of lcd_create_char() behavior

### DIFF
--- a/lcd.c
+++ b/lcd.c
@@ -151,6 +151,7 @@ void lcd_create_char(uint8_t location, uint8_t *charmap) {
   for (int i = 0; i < 8; i++) {
     lcd_write(charmap[i]);
   }
+  lcd_command(LCD_SETDDRAMADDR);
 }
 
 void lcd_set_cursor(uint8_t col, uint8_t row) {


### PR DESCRIPTION
At the moment, after studying api, you expect that the code for creating and displaying your symbol can be written like this:
```
lcd_create_char(location, charmap);
lcd_write(location); // but not working
```
But to work correctly, you need to write the following:
```
lcd_create_char(location, charmap);
lcd_command(LCD_SETDDRAMADDR);
lcd_write(location); // ok
```

The `lcd_create_char()` function is expected to create a new symbol, and will not affect the code after the call. But this is not so: the `lcd_create_char()` function does not return control from CGRAM to DDRAM, as a result, the code after calling `lcd_create_char()` may not work or work not as expected.

I changed the behavior of the `lcd_create_char()` function to a more obvious one, where control from CGRAM to DDRAM occurs at the end of the `lcd_create_char()` call. And now the given code is valid and works as expected:
```
lcd_create_char(location, charmap);
lcd_write(location); // work correctly
```